### PR TITLE
docs: rewrite README for professional onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,183 @@
-# 🕸️ FERRVMweb
+# FerrumWeb
 
-This is a recursive web crawler written in **Rust** that visits websites, extracts links, and stores them in a **SQLite database**.
+FerrumWeb is a recursive web crawler written in Rust.
+It starts from a root URL, discovers links, stores crawl results in SQLite, and provides Python-based visualization of the crawl graph.
 
-<div align ="center">
-<img width="620" height="670" alt="grafik" src="https://github.com/user-attachments/assets/ae13b986-6fbb-4978-8364-91a8d6fb77ee" />
-</div>
+## Highlights
 
-## Features
+- Recursive crawling with configurable max depth
+- Stores crawl graph in SQLite (`link` + `categories` tables)
+- Tracks parent-child URL relationships and depth
+- Optional interactive graph visualization with PyVis
+- Simple CLI workflow for quick local experiments
 
-- Extracts all links on the site
-- Persists data in a SQLite database (tables: `link`, `categories`)
-- Recursively crawls websites up to a configurable depth
-- Assigns category IDs based on URL keywords
-- Generates an interactive graph with category-based colors
-- Prints crawl statistics (nodes, edges, depth distribution)
+## Project Structure
 
-## Visualization
-
-Each link is saved with its **parent URL** and **depth level**, allowing you to visualize the structured hierarchy of your crawled website:
-
-## Interactive visualization with PyVis:
-
-<div align="center">
-  <img width="819" height="646" alt="grafik" src="png/hierarchy.png">
-</div>
-
-## Usage
-
-After crawling a website, visualize the link hierarchy using visualize_hierarchy.py:
-
-```bash
-#Optional: fill a test database
-python -u "visualize/link_db_test.py" # Fills data/links_test.db
-
-#Optional: seed categories (run once per database)
-python -u "visualize/categories_db_fill.py"
-
-#Visualize test database
-python -u "visualize/visualize_hierarchy.py" --db ./data/links_test.db
-
-#Generate interactive layout (default when no args)
-python -u "visualize/visualize_hierarchy.py"
+```text
+FerrumWeb/
+├── src/
+│   ├── main.rs           # CLI input flow + crawl entrypoint
+│   ├── crawler.rs        # Recursive crawler logic
+│   └── db.rs             # SQLite schema + inserts
+├── visualize/
+│   ├── visualize_hierarchy.py
+│   ├── categories_db_fill.py
+│   └── link_db_test.py
+├── data/
+│   ├── links.db
+│   └── links_test.db
+└── Cargo.toml
 ```
 
-**Output file:**
-- [interactive graph] `link_hierarchy.html` - interactive graph
+## Requirements
 
-## Crates
+### Rust crawler
 
-- [`reqwest`](https://docs.rs/reqwest/) – HTTP client  
-- [`scraper`](https://docs.rs/scraper/) – HTML parser  
-- [`rusqlite`](https://docs.rs/rusqlite/) – SQLite database integration 
+- Rust toolchain (stable recommended)
+- Build essentials for your platform
 
-## Installation
+Install Rust:
 
-Install Python dependencies:
+- https://www.rust-lang.org/tools/install
+
+### Python visualization
+
+- Python 3.9+
+- `networkx`
+- `pyvis`
+
+## Quick Start
+
+### 1) Clone and enter project
 
 ```bash
-pip install networkx
-pip install pyvis
-```
-
-PyVis: https://pyvis.readthedocs.io/en/latest/
-NetworkX: https://networkx.org/
-
-```bash
-git clone https://github.com/jakobx0/FerrumWeb
+git clone https://github.com/jakobx0/FerrumWeb.git
 cd FerrumWeb
-cargo run (if rust is not installed: https://www.rust-lang.org/tools/install )
 ```
 
-Rust help: https://users.rust-lang.org/t/link-exe-not-found-despite-build-tools-already-installed/47080
+### 2) Run crawler
 
-## Troubleshooting:
+```bash
+cargo run
+```
 
-On Windows the Error: `linker 'link.exe' not found` can be solved via:
+The CLI asks for:
+
+1. Start URL (e.g. `https://example.com`)
+2. Maximum depth (e.g. `2`)
+
+Results are written to:
+
+- `data/links.db`
+
+## Python Environment (recommended)
+
+Create and activate a virtual environment before installing visualization dependencies.
+
+### Linux/macOS
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install networkx pyvis
+```
+
+### Windows (PowerShell)
+
+```powershell
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install networkx pyvis
+```
+
+## Visualization Workflow
+
+### Option A: Use test data
+
+```bash
+python -u "visualize/link_db_test.py"
+python -u "visualize/categories_db_fill.py"
+python -u "visualize/visualize_hierarchy.py" --db ./data/links_test.db
+```
+
+### Option B: Use crawler output
+
+```bash
+python -u "visualize/categories_db_fill.py"
+python -u "visualize/visualize_hierarchy.py" --db ./data/links.db
+```
+
+Output:
+
+- `link_hierarchy.html` (interactive graph)
+
+Open it in your browser.
+
+## Database Schema
+
+FerrumWeb creates these tables:
+
+### `categories`
+
+- `category_id INTEGER PRIMARY KEY`
+- `category TEXT UNIQUE`
+
+### `link`
+
+- `id INTEGER PRIMARY KEY`
+- `url TEXT NOT NULL`
+- `parent_id INTEGER`
+- `depth INTEGER`
+- `category_id INTEGER` (FK to `categories.category_id`)
+
+## Known Limitations
+
+- Currently processes only absolute `http://` and `https://` links
+- No URL deduplication strategy in crawler/DB yet
+- Error handling can be improved in recursive path
+- Category matching logic in Python is currently simplistic
+
+## Troubleshooting
+
+### `cargo: command not found`
+
+Install Rust and restart shell:
+
+```bash
+rustup --version
+cargo --version
+```
+
+### Linux OpenSSL build issues (`openssl-sys`)
+
+```bash
+sudo apt update
+sudo apt install -y libssl-dev pkg-config
+```
+
+### Windows linker error: `link.exe not found`
+
+Try GNU toolchain fallback:
 
 ```bash
 rustup toolchain install stable-x86_64-pc-windows-gnu
 rustup default stable-x86_64-pc-windows-gnu
 ```
-For Linux the Error: `failed to run custom build command for 'openssl-sys v0.9.109'`:
 
-```bash
-sudo apt install libssl-dev
-```
+## Contributing
 
-## DB Usage
+Contributions are welcome.
 
-To analyse the DB file simply open a DBMS of your choice.
-For Example the **DB Browser for SQLite:**  https://sqlitebrowser.org/
+Suggested flow:
 
-<div align="center">
-  <img width="520" height="300" src="png/db_tabels.png" alt="FerrumWeb">
-</div>
+1. Fork the repository
+2. Create a feature branch
+3. Make focused commits
+4. Open a pull request with clear description and test steps
 
-Example SQL Queries:
+## License
 
-  Count of distinct URLs:
-  ```sql
-  SELECT COUNT(DISTINCT URL) FROM link;
-  ```
-  Grouped links by frequency:
-  ```sql
-    SELECT URL, COUNT(*) AS count FROM link GROUP BY URL ORDER BY count DESC;
-  ```
+No explicit license file is currently present in this repository.
+If you intend to reuse or distribute this code, clarify licensing with the repository owner first.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
 # FerrumWeb
 
 FerrumWeb is a recursive web crawler written in Rust.
-It starts from a root URL, discovers links, stores crawl results in SQLite, and provides Python-based visualization of the crawl graph.
+It starts from a root URL, discovers links, stores crawl results in SQLite, and provides Python based visualization of the crawl graph.
 
 ## Highlights
 
-- Recursive crawling with configurable max depth
-- Stores crawl graph in SQLite (`link` + `categories` tables)
-- Tracks parent-child URL relationships and depth
-- Optional interactive graph visualization with PyVis
-- Simple CLI workflow for quick local experiments
+- Recursive crawling with configurable maximum depth
+- Stores crawl data in SQLite using `link` and `categories` tables
+- Tracks parent child URL relationships and depth
+- Generates an interactive hierarchy graph with PyVis
+- Simple command line workflow for local experiments
+
+## Visualization Preview
+
+<div align="center">
+  <img width="819" height="646" alt="FerrumWeb hierarchy graph" src="png/hierarchy.png">
+</div>
 
 ## Project Structure
 
 ```text
 FerrumWeb/
 ├── src/
-│   ├── main.rs           # CLI input flow + crawl entrypoint
-│   ├── crawler.rs        # Recursive crawler logic
-│   └── db.rs             # SQLite schema + inserts
+│   ├── main.rs                  # CLI input flow and crawl entry point
+│   ├── crawler.rs               # Recursive crawler logic
+│   └── db.rs                    # SQLite schema and insert helpers
 ├── visualize/
 │   ├── visualize_hierarchy.py
 │   ├── categories_db_fill.py
@@ -26,6 +32,9 @@ FerrumWeb/
 ├── data/
 │   ├── links.db
 │   └── links_test.db
+├── png/
+│   ├── hierarchy.png
+│   └── db_tabels.png
 └── Cargo.toml
 ```
 
@@ -33,7 +42,7 @@ FerrumWeb/
 
 ### Rust crawler
 
-- Rust toolchain (stable recommended)
+- Rust toolchain, stable recommended
 - Build essentials for your platform
 
 Install Rust:
@@ -42,20 +51,20 @@ Install Rust:
 
 ### Python visualization
 
-- Python 3.9+
+- Python 3.9 or newer
 - `networkx`
 - `pyvis`
 
 ## Quick Start
 
-### 1) Clone and enter project
+### 1) Clone and enter the project
 
 ```bash
 git clone https://github.com/jakobx0/FerrumWeb.git
 cd FerrumWeb
 ```
 
-### 2) Run crawler
+### 2) Run the crawler
 
 ```bash
 cargo run
@@ -63,33 +72,33 @@ cargo run
 
 The CLI asks for:
 
-1. Start URL (e.g. `https://example.com`)
-2. Maximum depth (e.g. `2`)
+1. Start URL, for example `https://example.com`
+2. Maximum depth, for example `2`
 
-Results are written to:
+Crawl results are written to:
 
 - `data/links.db`
 
-## Python Environment (recommended)
+## Python Environment for Visualization
 
-Create and activate a virtual environment before installing visualization dependencies.
+The virtual environment is stored in `visualize`.
 
-### Linux/macOS
+### Linux and macOS
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip
-pip install networkx pyvis
+python3 -m venv ./visualize/.venv
+source ./visualize/.venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install networkx pyvis
 ```
 
-### Windows (PowerShell)
+### Windows PowerShell
 
 ```powershell
-python -m venv .venv
-.venv\Scripts\Activate.ps1
-pip install --upgrade pip
-pip install networkx pyvis
+python -m venv .\visualize\.venv
+.\visualize\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install networkx pyvis
 ```
 
 ## Visualization Workflow
@@ -111,9 +120,9 @@ python -u "visualize/visualize_hierarchy.py" --db ./data/links.db
 
 Output:
 
-- `link_hierarchy.html` (interactive graph)
+- `link_hierarchy.html` interactive graph
 
-Open it in your browser.
+Open `link_hierarchy.html` in your browser.
 
 ## Database Schema
 
@@ -130,36 +139,42 @@ FerrumWeb creates these tables:
 - `url TEXT NOT NULL`
 - `parent_id INTEGER`
 - `depth INTEGER`
-- `category_id INTEGER` (FK to `categories.category_id`)
+- `category_id INTEGER` foreign key to `categories.category_id`
+
+## Database Example View
+
+<div align="center">
+  <img width="520" height="300" src="png/db_tabels.png" alt="FerrumWeb database tables">
+</div>
 
 ## Known Limitations
 
 - Currently processes only absolute `http://` and `https://` links
-- No URL deduplication strategy in crawler/DB yet
-- Error handling can be improved in recursive path
+- No URL deduplication strategy in crawler or database yet
+- Error handling in recursive crawl paths can be improved
 - Category matching logic in Python is currently simplistic
 
 ## Troubleshooting
 
 ### `cargo: command not found`
 
-Install Rust and restart shell:
+Install Rust and restart your shell:
 
 ```bash
 rustup --version
 cargo --version
 ```
 
-### Linux OpenSSL build issues (`openssl-sys`)
+### Linux OpenSSL build issues with `openssl-sys`
 
 ```bash
 sudo apt update
 sudo apt install -y libssl-dev pkg-config
 ```
 
-### Windows linker error: `link.exe not found`
+### Windows linker error `link.exe not found`
 
-Try GNU toolchain fallback:
+Try the GNU toolchain fallback:
 
 ```bash
 rustup toolchain install stable-x86_64-pc-windows-gnu
@@ -170,14 +185,9 @@ rustup default stable-x86_64-pc-windows-gnu
 
 Contributions are welcome.
 
-Suggested flow:
+Suggested workflow:
 
 1. Fork the repository
 2. Create a feature branch
 3. Make focused commits
-4. Open a pull request with clear description and test steps
-
-## License
-
-No explicit license file is currently present in this repository.
-If you intend to reuse or distribute this code, clarify licensing with the repository owner first.
+4. Open a pull request with a clear description and test steps

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 FerrumWeb is a recursive web crawler written in Rust.
 It starts from a root URL, discovers links, stores crawl results in SQLite, and provides Python based visualization of the crawl graph.
 
+<div align="center">
+  <img width="819" height="646" alt="FerrumWeb" src="png/cmd.png">
+</div>
+
 ## Highlights
 
 - Recursive crawling with configurable maximum depth
@@ -12,6 +16,8 @@ It starts from a root URL, discovers links, stores crawl results in SQLite, and 
 - Simple command line workflow for local experiments
 
 ## Visualization Preview
+
+Each link is saved with its parent URL and depth level, allowing you to visualize the structured hierarchy of your crawled website.
 
 <div align="center">
   <img width="819" height="646" alt="FerrumWeb hierarchy graph" src="png/hierarchy.png">
@@ -34,6 +40,7 @@ FerrumWeb/
 │   └── links_test.db
 ├── png/
 │   ├── hierarchy.png
+|   ├──  cmd.png
 │   └── db_tabels.png
 └── Cargo.toml
 ```
@@ -146,13 +153,6 @@ FerrumWeb creates these tables:
 <div align="center">
   <img width="520" height="300" src="png/db_tabels.png" alt="FerrumWeb database tables">
 </div>
-
-## Known Limitations
-
-- Currently processes only absolute `http://` and `https://` links
-- No URL deduplication strategy in crawler or database yet
-- Error handling in recursive crawl paths can be improved
-- Category matching logic in Python is currently simplistic
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Rewrite README.md for clearer onboarding and resolve all latest review comments.

## What changed
- Kept a structured quick start and project overview
- Updated Python venv path to `./visualize/.venv` for Linux, macOS, and Windows
- Reused existing repository images:
  - `png/hierarchy.png`
  - `png/db_tabels.png`
- Removed the License section as requested
- Improved wording for clarity and consistency

## Validation
- Documentation only change
- Commands and paths reviewed against current repository layout